### PR TITLE
need `$self` on call to `set_status_code`

### DIFF
--- a/lib/Plack/Middleware/OpenTelemetry.pm
+++ b/lib/Plack/Middleware/OpenTelemetry.pm
@@ -90,7 +90,7 @@ sub call {
             $res,
             sub {
                 my $res = shift;
-                set_status_code($span, $res);
+                $self->set_status_code($span, $res);
                 my $content_length = Plack::Util::content_length($res->[2]);
                 $span->set_attribute("http.response_content_length", $content_length);
                 $span->set_attribute("plack.callback",               "true");


### PR DESCRIPTION
In the code dealing with a non arrayref `$res`, the `set_status_code` function is called without `$self`,  causing the following error
```
Too few arguments for subroutine 'Plack::Middleware::OpenTelemetry::set_status_code' (got 2; expected 3) at /usr/local/lib/perl5/site_perl/5.36.0/Plack/Middleware/OpenTelemetry.pm line 93.
 at /usr/local/lib/perl5/site_perl/5.36.0/Plack/Middleware/OpenTelemetry.pm line 93.
        Plack::Middleware::OpenTelemetry::set_status_code(OpenTelemetry::Trace::Span=ARRAY(0x563d22f08108), ARRAY(0x563d237373a0)) called at /usr/local/lib/perl5/site_perl/5.36.0/Plack/Middleware/OpenTe
lemetry.pm line 93
```
