### PR TITLE
Fix pod encoding error

### DIFF
--- a/lib/Plack/Middleware/OpenTelemetry.pm
+++ b/lib/Plack/Middleware/OpenTelemetry.pm
@@ -136,6 +136,8 @@ sub set_status_code ($self, $span, $res) {
 
 1;
 
+=encoding utf8
+
 =head1 NAME
 
 Plack::Middleware::OpenTelemetry - Plack middleware to setup OpenTelemetry spans


### PR DESCRIPTION
When I view this module with metacpan or the perldoc command, an error occurs. 
Specifying the encoding fixes it, so I made the correction.

```
POD ERRORS
    Hey! The above document had some coding errors, which are explained
    below:

    Around line 177:
        Non-ASCII character seen before =encoding in 'Bjørn'. Assuming UTF-8
```
<https://metacpan.org/pod/Plack::Middleware::OpenTelemetry>