### PR TITLE
Remove the version specification and add care for using the experimental signature.

### DIFF
--- a/lib/Plack/Middleware/OpenTelemetry.pm
+++ b/lib/Plack/Middleware/OpenTelemetry.pm
@@ -2,10 +2,12 @@ package Plack::Middleware::OpenTelemetry;
 
 # ABSTRACT: Plack middleware to setup OpenTelemetry tracing
 
-use v5.36.0;
 use strict;
 use warnings;
+
 use feature 'signatures';
+no warnings 'experimental::signatures';
+
 use parent qw(Plack::Middleware);
 use Plack::Util::Accessor qw(resource_attributes include_client_errors);
 use OpenTelemetry -all;


### PR DESCRIPTION
Normally, Perl will warning if you specify a version of Perl using `use` that is newer than the currently running version. In this case, Perl 5.36 or higher is required, but often the running Perl version is older. Therefore, I removed the version specification to allow this module to work on older versions of Perl.

Removing v5.36 will allow for compatibility, but then the new features `try` and `signatures` won't work. `try` can still function on older versions thanks to 'Feature::Compat::Try', so it will work as is. However, signatures might still run, but it could generate warnings. Thus, I implemented control over these warnings. (Another option would have been to stop using signatures, but this time I decided to keep them as they are.)