### PR TITLE
Make sure Plack is loaded

### DIFF
--- a/lib/Plack/Middleware/OpenTelemetry.pm
+++ b/lib/Plack/Middleware/OpenTelemetry.pm
@@ -7,6 +7,7 @@ use strict;
 use warnings;
 use feature 'signatures';
 use parent qw(Plack::Middleware);
+use Plack;
 use Plack::Util::Accessor qw(resource_attributes include_client_errors);
 use OpenTelemetry -all;
 use OpenTelemetry::Constants qw( SPAN_KIND_SERVER SPAN_STATUS_ERROR SPAN_STATUS_OK );


### PR DESCRIPTION
This middleware injects the Plack version into the resource, but it assumes that the version will be available. This is often the case, but is not guaranteed. Calling a sample app like this one:

    $ plackup --server Net::Async::HTTP::Server -e '
        use OpenTelemetry::SDK;
        enable "Plack::Middleware::OpenTelemetry";
        sub { [ 200, [], ["OK"] ] }
    '

results in the following printed to the logs:

    Plack::Handler::Net::Async::HTTP::Server: Accepting connections at http://0:5000/
    Use of uninitialized value $Plack::VERSION in string at .../Plack/Middleware/OpenTelemetry.pm line 61.
    127.0.0.1 - - [22/May/2025:22:11:44 +0100] "GET / HTTP/1.1" 200 2 "-" "curl/7.81.0"

This change ensures the version is available by loading Plack from the middleware.